### PR TITLE
Fixed attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default {
 |-----------------|---------------|-------------|---------------------------------------|
 | range           | Boolean       | false       | if true, the type is daterange        |
 | format          | String        | yyyy-MM-dd  | Date formatting string                |
-| language        | String        | zh          | Translation (en/zh)      |
+| lang            | String        | zh          | Translation (en/zh)      |
 | placeholder     | String        |             | input placeholder text                |
 | width           | String/Number | 210         | input size                            |
 


### PR DESCRIPTION
You have described the language attribute as `language`, but the one that works is `lang`.