### PR TITLE
Fixed Typos in spanish language

### DIFF
--- a/datepicker/languages.js
+++ b/datepicker/languages.js
@@ -29,7 +29,7 @@ export default {
   'es': {
     'days': ['Dom', 'Lun', 'mar', 'Mie', 'Jue', 'Vie', 'Sab'],
     'months': ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-    'pickers': ['próximos 7 días', 'próximos 30 días', '7 dás anteriores', '30 das anteriores'],
+    'pickers': ['próximos 7 días', 'próximos 30 días', '7 días anteriores', '30 días anteriores'],
     'placeholder': {
       'date': 'Seleccionar fecha',
       'dateRange': 'Seleccionar un rango de fechas'


### PR DESCRIPTION
Fixed "dás" to "días" in spanish.