### PR TITLE
Make setting the width more dynamic by allowing the use of CSS units

### DIFF
--- a/datepicker/index.vue
+++ b/datepicker/index.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="mx-datepicker"
   :class="{'disabled': disabled}"
-  :style="{'width': width + 'px','min-width':range ? (type === 'datetime' ? '320px' : '210px') : '140px'}"
+  :style="{'width': computedWidth,'min-width':range ? (type === 'datetime' ? '320px' : '210px') : '140px'}"
   v-clickoutside="closePopup">
   <input name="date"
     :disabled="disabled"
@@ -209,6 +209,16 @@ export default {
         )
       }
       return ''
+    },
+    computedWidth () {
+      if (typeof this.width === 'string' && this.width.match(/(px|%|rem|em|ex)$/)) {
+        return this.width
+      }
+      if (typeof this.width === 'string') {
+        return this.width.replace(/\D/g,'') + 'px'
+      }
+      
+      return this.width + 'px'
     }
   },
   methods: {


### PR DESCRIPTION
Allow users to set the width parameter by using a CSS measurement unit (%, em, rem...).
In issue #71 it is requested to be able to set the width to 100%.

By default, the width is still set to pixels if the parameter is sent as a number or a non-valid unit.