### PR TITLE
Document format string tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,28 +48,28 @@ export default {
 ```
 ### Attributes
 
-| Prop                | Type          | Default     | Description                                         |
-|---------------------|---------------|-------------|-----------------------------------------------------|
-| type                | String        | 'date'      | select datepicker or datetimepicker(date/datetime)  |
-| range               | Boolean       | false       | if true, the type is daterange or datetimerange     |
-| format              | String        | yyyy-MM-dd  | Date formatting string                              |
-| custom-formatter    | function      | null        | custom Date display                                 |
-| lang                | String/Object | zh          | Translation (en/zh/es/pt-br/fr/ru/de/it/cs)(custom) |
-| confirm             | Boolean       | false       | if true, need click the button to change the value  |
-| disabled            | Boolean       | false       | Disable the component                               |
-| editable            | Boolean       | false       | if true, user can type it(only the range is false)  |
-| placeholder         | String        |             | input placeholder text                              |
-| width               | String/Number | 210         | input size                                          |
-| disabled-days       | Array         | []          | Days in YYYY-MM-DD format to disable                |
-| not-before          | String/Date   | ''          | Disable all dates before new Date(not-before)       |
-| not-after           | String/Date   | ''          | Disable all dates after new Date(not-after)         |
-| shortcuts           | Boolean/Array | true        | the shortcuts for the range picker                  |
-| time-picker-options | Object        | {}          | set timePickerOptions(start, step, end)             |
-| minute-step         | Number        | 0           | if > 0 don't show the second picker(0 - 60)         |
-| first-day-of-week   | Number        | 7           | set the first day of week (1-7)                     |
-| input-class         | String        | 'mx-input'  | the input class name                                |
-| confirm-text        | String        | 'OK'        | the default text to display on confirm button       |
-| range-separator     | String        | '~'         | the range separator text                            |
+| Prop                | Type          | Default    | Description                                          |
+|---------------------|---------------|------------|------------------------------------------------------|
+| type                | String        | 'date'     | select datepicker or datetimepicker(date/datetime)   |
+| range               | Boolean       | false      | if true, the type is daterange or datetimerange      |
+| format              | String        | yyyy-MM-dd | Date formatting string - see "Date Formatting" below |
+| custom-formatter    | function      | null       | Custom date formatter - see "Date Formatting" below  |
+| lang                | String/Object | zh         | Translation (en/zh/es/pt-br/fr/ru/de/it/cs)(custom)  |
+| confirm             | Boolean       | false      | if true, need click the button to change the value   |
+| disabled            | Boolean       | false      | Disable the component                                |
+| editable            | Boolean       | false      | if true, user can type it(only the range is false)   |
+| placeholder         | String        |            | input placeholder text                               |
+| width               | String/Number | 210        | input size                                           |
+| disabled-days       | Array         | []         | Days in YYYY-MM-DD format to disable                 |
+| not-before          | String/Date   | ''         | Disable all dates before new Date(not-before)        |
+| not-after           | String/Date   | ''         | Disable all dates after new Date(not-after)          |
+| shortcuts           | Boolean/Array | true       | the shortcuts for the range picker                   |
+| time-picker-options | Object        | {}         | set timePickerOptions(start, step, end)              |
+| minute-step         | Number        | 0          | if > 0 don't show the second picker(0 - 60)          |
+| first-day-of-week   | Number        | 7          | set the first day of week (1-7)                      |
+| input-class         | String        | 'mx-input' | the input class name                                 |
+| confirm-text        | String        | 'OK'       | the default text to display on confirm button        |
+| range-separator     | String        | '~'        | the range separator text                             |
 
 
 #### lang
@@ -114,6 +114,38 @@ export default {
 |-----------------|------------------------------|------------------------|
 | change          | When user select date        | the currentValue       |
 | confirm         | When user click 'OK' button  | the currentValue       |
+
+
+### Date Formatting
+
+The "format" string supports a limited set of formatting tokens. For more
+expressive date formats  an arbitrary date formatter function can be provided
+via the "custom-formatter" property. The supported format string tokens are:
+
+| Field        | Token | Output                  |
+|--------------|-------|-------------------------|
+| Year         | YY    | 70 71 ... 29 30         |
+|              | YYYY  | 1970 1971 ... 2029 2030 |
+| Month        | M     | 1 2 ... 11 12           |
+|              | MM    | 01 02 ... 11 12         |
+| Day of Month | D     | 1 2 ... 30 31           |
+|              | DD    | 01 02 ... 30 31         |
+| Hour         | H     | 0 1 ... 22 23           |
+|              | HH    | 00 01 ... 22 23         |
+|              | h     | 1 2 ... 11 12           |
+|              | hh    | 01 02 ... 11 12         |
+| AM/PM        | a     | am pm                   |
+|              | A     | AM PM                   |
+| Minute       | m     | 0 1 ... 58 59           |
+|              | mm    | 00 01 ... 58 59         |
+| Second       | s     | 0 1 ... 58 59           |
+|              | s     | 00 01 ... 58 59         |
+| Millisecond  | S     | 0 1 ... 8 9             |
+|              | SS    | 00 01 ... 98 99         |
+|              | SSS   | 000 001 ... 998 999     |
+| Quarter      | q     | 1 2 3 4                 |
+|              | qq    | 01 02 03 04             |
+
 
 ## License
 


### PR DESCRIPTION
It took me a while to work out how to use the custom formatter to get the date format I wanted so I've updated the readme to document in more detail the supported date formatting options. I've structured the format tokens table the same as the moment.js documentation.

Thanks for the awesome library!