### PR TITLE
Fix index.scss to not include last shortcut pipe

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -136,6 +136,9 @@ $primary-color: #1284e7;
       margin: 0 10px;
       color: #48576a;
     }
+    &:last-of-type:after {
+      content: none;
+    }
   }
 }
 


### PR DESCRIPTION
Removes the final "after" pipe character from the shortcut range selection list.

![image](https://user-images.githubusercontent.com/4014841/44661968-59d69580-a9da-11e8-9cf3-0295a7f141ec.png)
