### PR TITLE
fix: use refs instead of children array

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -63,6 +63,7 @@
       <calendar-panel
         v-if="!range"
         v-bind="$attrs"
+        ref="calendarPanel"
         :type="innerType"
         :date-format="innerDateFormat"
         :value="currentValue"
@@ -74,6 +75,7 @@
         <calendar-panel
           style="box-shadow:1px 0 rgba(0, 0, 0, .1)"
           v-bind="$attrs"
+          ref="calendarPanel"
           :type="innerType"
           :date-format="innerDateFormat"
           :value="currentValue[0]"
@@ -487,8 +489,7 @@ export default {
     handleChange (event) {
       const value = event.target.value
       if (this.editable && this.userInput !== null) {
-        const calendar = this.$children[0]
-        const checkDate = calendar.isDisabledTime
+        const checkDate = this.$refs.calendarPanel.isDisabledTime
         if (!value) {
           this.clearDate()
           return


### PR DESCRIPTION
On our projects we have an issue on some slow mobile devices when we are unable to access **isDisabledTime** function from calendar-panel comp. Writing code like `$children[0]` is a bad practice coz documentation says: 

> Note there’s no order guarantee for $children

I think that $refs usage instead of $children may solve this problem. 