### PR TITLE
feat: add click-outside-mode prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ export default {
 |------|--------------|-------|---------|
 | type | select date type  | 'date' \| 'datetime' \| 'year' \| 'month' \| 'time' | 'date' |
 | range | if true, the type is daterange or datetimerange | `boolean` | false |
-| format | format the Date. The parsing tokens are similar to the moment.js | [token](https://github.com/taylorhakes/fecha#formatting-tokens) \| [`object`](https://github.com/mengxiong10/vue2-datepicker/issues/232#issuecomment-458558141) | 'YYYY-MM-DD' |  
+| format | format the Date. The parsing tokens are similar to the moment.js | [token](https://github.com/taylorhakes/fecha#formatting-tokens) \| [`object`](https://github.com/mengxiong10/vue2-datepicker/issues/232#issuecomment-458558141) | 'YYYY-MM-DD' |
 | value-type | type of binding value. If not specified, the binding value will be a Date object | [value-type](#value-type) | 'date' |
 | lang | Translation | [lang](#lang) | 'zh' |
 | clearable | if false, don't show the clear icon | `boolean` | true |
+| click-outside-mode | if 'all', all outside clicks will close the current date-picker | 'all' \| 'allExceptDatePickers' | 'allExceptDatePickers' |
 | confirm | if true, need click the button to change the value | `boolean` | false |
 | editable | if false, user cann't type it | `boolean` | true |
 | disabled | Disable the component | `boolean` | false |
@@ -101,7 +102,7 @@ export default {
 | not-after | Disable all dates after new Date(not-after) | `string`\|`Date`| '' |
 | disabled-days | Disable Days | `(date) => boolean` | - |
 | shortcuts | the shortcuts for the range picker | [shortcuts](#shortcuts) | true |
-| time-picker-options | custom time-picker | [time-picker-options](#time-picker-options) | null |           
+| time-picker-options | custom time-picker | [time-picker-options](#time-picker-options) | null |
 | minute-step | if > 0 don't show the second picker | 0 - 60 | 0 |
 | first-day-of-week | set the first day of week | 1 - 7  | 7 |
 | input-class | the input class name | `string` | 'mx-input' |
@@ -114,7 +115,7 @@ export default {
 set the format of binding value
 
 | Value           | Description                               |
-|-----------------|-------------------------------------------|     
+|-----------------|-------------------------------------------|
 | date            | binding value will be a Date object       |
 | timestamp       | binding value will be a timestamp number  |
 | format          | binding value will be the format string   |
@@ -138,7 +139,7 @@ Advanced: You can also customize objects to implement two functions.
 the shortcuts for the range picker
 
 | Value           | Description |
-|-----------------|-------------|     
+|-----------------|-------------|
 | true            | show the default shortcuts |
 | false           | hide the defaualt shortcuts  |
 | [{text: string, onClick: () => any }] | custom shortcuts |
@@ -167,7 +168,7 @@ custom time-picker
 #### panel
 
 | Value | Description          |
-|-------|----------------------|     
+|-------|----------------------|
 | NONE  | when panel is closed |
 | DATE  | when panel is date   |
 | YEAR  | when panel is year   |
@@ -177,12 +178,12 @@ custom time-picker
 ### Slots
 
 | Name            | Description              |
-|-----------------|--------------------------|     
+|-----------------|--------------------------|
 | calendar-icon   | custom the calender icon |
 | header          | popup header             |
 | footer          | popup footer             |
 
-## ChangeLog 
+## ChangeLog
 
 [CHANGELOG](CHANGELOG.md)
 

--- a/src/directives/clickoutside.js
+++ b/src/directives/clickoutside.js
@@ -1,8 +1,18 @@
-
 export default {
   bind (el, binding, vnode) {
     el['@clickoutside'] = e => {
+      let prevent = false
+      if (vnode.context.clickOutsideMode === 'allExceptDatePickers') {
+        let pickers = Array.from(document.querySelectorAll('div.mx-datepicker'))
+
+        let index
+        if ((index = pickers.indexOf(el)) > -1) pickers.splice(index, 1)
+
+        prevent = pickers.some(p => p.contains(e.target))
+      }
+
       if (
+        !prevent &&
         !el.contains(e.target) &&
         !(vnode.context.popupElm && vnode.context.popupElm.contains(e.target)) &&
         binding.expression &&

--- a/src/index.vue
+++ b/src/index.vue
@@ -10,7 +10,7 @@
     }"
     v-clickoutside="closePopup">
     <div class="mx-input-wrapper"
-      @click.stop="showPopup">
+      @click="showPopup">
       <input
         :class="inputClass"
         :name="inputName"
@@ -50,7 +50,7 @@
     <div class="mx-datepicker-popup"
       :style="innerPopupStyle"
       v-show="popupVisible"
-      @click.stop.prevent
+      @click.prevent
       ref="calendar">
       <slot name="header">
         <div class="mx-shortcuts-wrapper"
@@ -165,6 +165,13 @@ export default {
     width: {
       type: [String, Number],
       default: null
+    },
+    clickOutsideMode: {
+      type: String,
+      default: 'allExceptDatePickers',
+      validator: function (value) {
+        return ['all', 'allExceptDatePickers'].indexOf(value) !== -1
+      }
     },
     confirmText: {
       type: String,


### PR DESCRIPTION
This feature adds the ability to customize the click-outside behavior through the `click-outside-mode` prop:
- by default, `allExceptDatePickers` will keep the date-picker opened when the user clicks on any date-picker field / popup
- `all` will close the current date-picker if the user clicks anywhere outside the current date-picker

It doesn't break the current behavior, since it seems to be expected & wanted by design.
But it would fulfill #207.

I've also added the related documentation.
Feel free to make edits if needed.