### PR TITLE
feat: add close-on prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export default {
 | shortcuts | the shortcuts for the range picker | [shortcuts](#shortcuts) | true |
 | time-picker-options | custom time-picker | [time-picker-options](#time-picker-options) | null |           
 | minute-step | if > 0 don't show the second picker | 0 - 60 | 0 |
+| close-on | closes the popup when the user clicks on the specified time type | 'none' \| 'hour' \| 'minute' \| 'second' | 'none' |
 | first-day-of-week | set the first day of week | 1 - 7  | 7 |
 | input-class | the input class name | `string` | 'mx-input' |
 | input-attr | the input attr(eg: { required: true, id: 'input'}) | `object` | — |

--- a/src/calendar.vue
+++ b/src/calendar.vue
@@ -347,8 +347,8 @@ export default {
       }
       this.showPanelDate()
     },
-    selectTime (time) {
-      this.$emit('select-time', time, false)
+    selectTime (time, type) {
+      this.$emit('select-time', time, false, type)
     },
     pickTime (time) {
       this.$emit('select-time', time, true)

--- a/src/index.vue
+++ b/src/index.vue
@@ -170,6 +170,13 @@ export default {
       type: String,
       default: 'OK'
     },
+    closeOn: {
+      type: String,
+      default: 'none',
+      validator: function (value) {
+        return ['none', 'hour', 'minute', 'second'].indexOf(value) !== -1
+      }
+    },
     confirm: {
       type: Boolean,
       default: false
@@ -451,15 +458,16 @@ export default {
         this.updateDate()
       }
     },
-    selectTime (time, close) {
+    selectTime (time, close, type) {
       this.currentValue = time
-      this.updateDate() && close && this.closePopup()
+      this.updateDate() && (close || (this.closeOn === type)) && this.closePopup()
     },
     selectStartTime (time) {
       this.selectStartDate(time)
     },
-    selectEndTime (time) {
+    selectEndTime (time, close, type) {
       this.selectEndDate(time)
+      if (this.closeOn === type) this.closePopup()
     },
     showPopup () {
       if (this.disabled) {

--- a/src/panel/time.js
+++ b/src/panel/time.js
@@ -38,11 +38,11 @@ export default {
     stringifyText (value) {
       return ('00' + value).slice(String(value).length)
     },
-    selectTime (time) {
+    selectTime (time, type) {
       if (typeof this.disabledTime === 'function' && this.disabledTime(time)) {
         return
       }
-      this.$emit('select', new Date(time))
+      this.$emit('select', new Date(time), type)
     },
     pickTime (time) {
       if (typeof this.disabledTime === 'function' && this.disabledTime(time)) {
@@ -129,7 +129,7 @@ export default {
             actived: i === this.currentHours,
             disabled: disabledTime && disabledTime(time)
           }}
-          onClick={this.selectTime.bind(this, time)}
+          onClick={this.selectTime.bind(this, time, 'hour')}
         >
           {this.stringifyText(i)}
         </li>
@@ -148,7 +148,7 @@ export default {
             actived: value === this.currentMinutes,
             disabled: disabledTime && disabledTime(time)
           }}
-          onClick={this.selectTime.bind(this, time)}
+          onClick={this.selectTime.bind(this, time, 'minute')}
         >
           {this.stringifyText(value)}
         </li>
@@ -164,7 +164,7 @@ export default {
             actived: i === this.currentSeconds,
             disabled: disabledTime && disabledTime(time)
           }}
-          onClick={this.selectTime.bind(this, time)}
+          onClick={this.selectTime.bind(this, time, 'second')}
         >
           {this.stringifyText(i)}
         </li>

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -685,7 +685,7 @@ describe('time-panel', () => {
     minutes.at(1).trigger('click')
     seconds.at(1).trigger('click')
     expect(wrapper.emitted()).toEqual({
-      select: [[new Date(2018, 5, 5, 1)], [new Date(2018, 5, 5, 0, 1)], [new Date(2018, 5, 5, 0, 0, 1)]]
+      select: [[new Date(2018, 5, 5, 1), 'hour'], [new Date(2018, 5, 5, 0, 1), 'minute'], [new Date(2018, 5, 5, 0, 0, 1), 'second']]
     })
   })
 


### PR DESCRIPTION
This feature allows to make the popup close when the user clicks on a given time type (hour, minute or second).

For example, if I want the popup to close when the user clicks on a minute, I'll just need to set the `close-on` prop to `'minute'` (default = 'none').

It also works for datetime range, closes only during the endTime selection.

I've also added the related documentation.
Feel free to make edits if needed.