### PR TITLE
feat: includedEndDate

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lib",
     "src"
   ],
-  "version": "2.11.2",
+  "version": "2.11.3",
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --hot --open --config build/webpack.dev.config.js",
     "demo": "cross-env NODE_ENV=production webpack --progress --hide-modules --config build/webpack.demo.config.js",

--- a/src/index.vue
+++ b/src/index.vue
@@ -165,6 +165,10 @@ export default {
       type: String,
       default: '~'
     },
+    includedEndDate: {
+      type: Boolean,
+      default: false
+    },
     width: {
       type: [String, Number],
       default: null
@@ -454,6 +458,9 @@ export default {
       }
     },
     selectEndDate (date) {
+      if (this.innerType === 'date' && this.includedEndDate) {
+        date = date.setHours(23, 59, 59, 999)
+      }
       this.$set(this.currentValue, 1, date)
       if (this.currentValue[0]) {
         this.updateDate()


### PR DESCRIPTION
当 `range && type=='date'` 时，结束日期的时间为 `00:00:00` ，增加了 `prop: includedEndDate` ，为 `true` 时，时间为 `23:59:59:999`