### PR TITLE
Stop popup closes when shortcut is click when it should not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ the shortcuts for the range picker
 | Value           | Description |
 |-----------------|-------------|
 | true            | show the default shortcuts |
-| false           | hide the defaualt shortcuts  |
-| [{text: string, onClick: () => any }] | custom shortcuts |
+| false           | hide the default shortcuts  |
+| [{text: string, onClick: (datepicker) => any }] | custom shortcuts with full customisation of event. if `false` is returned, the pop-up will not close |
+| [{text: string, start: Date, end: Date}] | custom shortcuts updating current widget start and end dates |
 
 #### time-picker-options
 custom time-picker

--- a/src/index.vue
+++ b/src/index.vue
@@ -399,7 +399,9 @@ export default {
       } else {
         this.currentValue = [new Date(range.start), new Date(range.end)]
         this.updateDate(true)
-        this.closePopup()
+        if (!this.confirm) {
+          this.closePopup()
+        }
       }
     },
     clearDate () {


### PR DESCRIPTION
Fixes #316

If `confirm` is specified, when clicking on a shortcut, it should not close the popup.

Also updated README to make it more clear what can be passed to the `shortcuts` prop.