### PR TITLE
rename t() to transtlateFn()

### DIFF
--- a/src/calendar/calendar-panel.vue
+++ b/src/calendar/calendar-panel.vue
@@ -125,7 +125,7 @@ export default {
   },
   mixins: [emitter],
   inject: {
-    t: {
+    translateFn: {
       default: () => getLocaleFieldValue,
     },
     prefixClass: {
@@ -207,9 +207,9 @@ export default {
       return this.panel === 'date';
     },
     dateHeader() {
-      const monthBeforeYear = this.t('monthBeforeYear');
-      const yearFormat = this.t('yearFormat');
-      const monthFormat = this.t('monthFormat') || 'MMM';
+      const monthBeforeYear = this.translateFn('monthBeforeYear');
+      const yearFormat = this.translateFn('yearFormat');
+      const monthFormat = this.translateFn('monthFormat') || 'MMM';
       const yearLabel = {
         panel: 'year',
         label: this.formatDate(this.innerCalendar, yearFormat),
@@ -235,7 +235,7 @@ export default {
   },
   methods: {
     formatDate(date, fmt) {
-      return format(date, fmt, { locale: this.t('formatLocale') });
+      return format(date, fmt, { locale: this.translateFn('formatLocale') });
     },
     initCalendar() {
       let calendarDate = this.calendar;

--- a/src/calendar/table-date.vue
+++ b/src/calendar/table-date.vue
@@ -39,7 +39,7 @@ import { getLocaleFieldValue } from '../locale';
 export default {
   name: 'TableDate',
   inject: {
-    t: {
+    translateFn: {
       default: () => getLocaleFieldValue,
     },
     getWeek: {
@@ -85,10 +85,10 @@ export default {
   },
   computed: {
     firstDayOfWeek() {
-      return this.t('formatLocale.firstDayOfWeek') || 0;
+      return this.translateFn('formatLocale.firstDayOfWeek') || 0;
     },
     days() {
-      const days = this.t('days') || this.t('formatLocale.weekdaysMin');
+      const days = this.translateFn('days') || this.translateFn('formatLocale.weekdaysMin');
       return days.concat(days).slice(this.firstDayOfWeek, this.firstDayOfWeek + 7);
     },
     dates() {
@@ -125,7 +125,7 @@ export default {
   },
   methods: {
     formatDate(date, fmt) {
-      return format(date, fmt, { locale: this.t('formatLocale') });
+      return format(date, fmt, { locale: this.translateFn('formatLocale') });
     },
     handleCellClick(evt) {
       let { target } = evt;
@@ -148,7 +148,7 @@ export default {
       const year = this.calendarYear;
       const month = this.calendarMonth;
       const date = createDate(year, month, day);
-      return this.getWeek(date, this.t('formatLocale'));
+      return this.getWeek(date, this.translateFn('formatLocale'));
     },
   },
 };

--- a/src/calendar/table-month.vue
+++ b/src/calendar/table-month.vue
@@ -21,7 +21,7 @@ import { getLocaleFieldValue } from '../locale';
 export default {
   name: 'TableMonth',
   inject: {
-    t: {
+    translateFn: {
       default: () => getLocaleFieldValue,
     },
     prefixClass: {
@@ -38,7 +38,8 @@ export default {
   },
   computed: {
     months() {
-      const monthsLocale = this.t('months') || this.t('formatLocale.monthsShort');
+      const monthsLocale =
+        this.translateFn('months') || this.translateFn('formatLocale.monthsShort');
       const months = monthsLocale.map((text, month) => {
         return { text, month };
       });

--- a/src/date-picker.vue
+++ b/src/date-picker.vue
@@ -151,7 +151,7 @@ export default {
   },
   provide() {
     return {
-      t: this.getLocaleFieldValue,
+      translateFn: this.getLocaleFieldValue,
       getWeek: this.getWeek,
       prefixClass: this.prefixClass,
     };

--- a/src/time/list-options.vue
+++ b/src/time/list-options.vue
@@ -40,7 +40,7 @@ export default {
   name: 'ListOptions',
   components: { ScrollbarVertical },
   inject: {
-    t: {
+    translateFn: {
       default: () => getLocaleFieldValue,
     },
     prefixClass: {
@@ -99,7 +99,7 @@ export default {
   },
   methods: {
     formatDate(date, fmt) {
-      return format(date, fmt, { locale: this.t('formatLocale') });
+      return format(date, fmt, { locale: this.translateFn('formatLocale') });
     },
     scrollToSelected() {
       const element = this.$el.querySelector('.active');

--- a/src/time/time-panel.vue
+++ b/src/time/time-panel.vue
@@ -47,7 +47,7 @@ export default {
   name: 'TimePanel',
   components: { ListColumns, ListOptions },
   inject: {
-    t: {
+    translateFn: {
       default: () => getLocaleFieldValue,
     },
     prefixClass: {
@@ -149,7 +149,7 @@ export default {
   },
   methods: {
     formatDate(date, fmt) {
-      return format(date, fmt, { locale: this.t('formatLocale') });
+      return format(date, fmt, { locale: this.translateFn('formatLocale') });
     },
     isDisabled(date) {
       return this.disabledTime(new Date(date));


### PR DESCRIPTION
I've found a problem with `t()` injection in some cases. Some vue translation plugins add `t()` to global vue scope which causes name collision & errors (You can see them here: https://jsfiddle.net/1gc4xj5h/1/).

As it is quite hard to change translation plugin in large project I came with idea of renaming it in your (great!) plugin cause it "visible" only internally.