### PR TITLE
Fix stopPropagation on undefined event

### DIFF
--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -332,7 +332,9 @@ export default {
       }
     },
     handleClear(evt) {
-      evt.stopPropagation();
+      if (evt) {
+        evt.stopPropagation();
+      }
       this.emitValue(this.range ? [null, null] : null);
       this.$emit('clear');
     },


### PR DESCRIPTION
From `handleInputChange` we call `handleClear` manually, without event to stop propagation on.