### PR TITLE
feat: add prop `required`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ You can also override some of the default locale by `lang`.
 | default-value       | default date of the calendar                     | `Date`                                      | new Date()     |
 | lang                | override the default locale                      | `object`                                    |                |
 | placeholder         | input placeholder text                           | `string`                                    | ''             |
+| required            | input html attribute required                    | `boolean`                                   | false          |
 | editable            | whether the input is editable                    | `boolean`                                   | true           |
 | clearable           | if false, don't show the clear icon              | `boolean`                                   | true           |
 | confirm             | if true, need click the button to change value   | `boolean`                                   | false          |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,7 @@ import 'vue2-datepicker/locale/zh-cn';
 | default-value       | 设置日历默认的时间                               | `Date`                                      | new Date()     |
 | lang                | 覆盖默认的语音设置                               | `object`                                    |                |
 | placeholder         | 输入框的 placeholder                             | `string`                                    | ''             |
+| required            | input html attribute required                    | `boolean`                                   | false          |
 | editable            | 输入框是否可以输入                               | `boolean`                                   | true           |
 | clearable           | 是否显示清除按钮                                 | `boolean`                                   | true           |
 | confirm             | 是否需要确认                                     | `boolean`                                   | false          |

--- a/__test__/__snapshots__/date-picker.test.js.snap
+++ b/__test__/__snapshots__/date-picker.test.js.snap
@@ -114,6 +114,48 @@ exports[`DatePicker prop: editable 1`] = `
 </div>
 `;
 
+exports[`DatePicker prop: required 1`] = `
+<div
+  class="mx-datepicker"
+>
+  <div
+    class="mx-input-wrapper"
+  >
+    <input
+      autocomplete="off"
+      class="mx-input"
+      name="date"
+      placeholder=""
+      required="required"
+      type="text"
+    />
+    <i
+      class="mx-icon-clear"
+    >
+      <anonymous-stub />
+    </i>
+    <i
+      class="mx-icon-calendar"
+    >
+      <anonymous-stub />
+    </i>
+  </div>
+  <popup-stub
+    appendtobody="true"
+  >
+    <div
+      class="mx-datepicker-content"
+    >
+      <div
+        class="mx-datepicker-body"
+      >
+        <div />
+      </div>
+    </div>
+  </popup-stub>
+</div>
+`;
+
 exports[`DatePicker prop: formatter 1`] = `
 <table
   class="mx-table mx-table-date"

--- a/__test__/date-picker.test.js
+++ b/__test__/date-picker.test.js
@@ -107,6 +107,20 @@ describe('DatePicker', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  it('prop: required', () => {
+    wrapper = shallowMount(DatePicker, {
+      propsData: {
+        value: new Date(2019, 4, 10),
+        defaultValue: new Date(2019, 4, 10),
+        required: true,
+      },
+      scopedSlots: {
+        content: '<div></div>',
+      },
+    });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
   it('prop: attrs of input', () => {
     wrapper = shallowMount(DatePicker, {
       propsData: {

--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -77,6 +77,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    required: {
+      type: Boolean,
+      default: false,
+    },
     clearable: {
       type: Boolean,
       default: true,
@@ -447,6 +451,7 @@ export default {
         readonly: !this.editable,
         disabled: this.disabled,
         placeholder: this.placeholder,
+        required: this.required,
         ...this.inputAttr,
       };
       const { value, ...attrs } = props;


### PR DESCRIPTION
Hey @mengxiong10,

i recently recognized, that i can't use the required-prop directly on the datepicker. While digging through code, i indeed recognized, i could do it with inputAttr. But as i see the required-prop on input-fields on the same level as e.g. placeholder or disabled props, i think it would be an advantage, if your datepicker exposes the required prop just like the others.

So - here it is, i hope i didn't miss any todo, i just added to pass the required-prop to the input field. A Test i added too, mainly copied from editable prop and adapted, it runs through, even that i'm not 100% sure, if i missed something there. Docs are accordingly adapted, just the chinese text i was not able to write. Feel free to amend to this commit to fix the chinese text. 😉 

Greets!
Jonas

PS: Thank you by that way for your work and care on this useful component! :)