### PR TITLE
feat: add event keyup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     'no-param-reassign': 'off',
     'no-restricted-globals': 'off',
     'import/prefer-default-export': 'off',
-    'import/no-unresolved': [2, { ignore: ['vue2-datepicker'] }],
+    'import/no-unresolved': [2, { ignore: ['vue2-datepicker-keyup'] }],
     'import/no-extraneous-dependencies': 'off',
     'vue/require-default-prop': 'off',
     'vue/require-prop-types': 'off',

--- a/build/bin/locale.js
+++ b/build/bin/locale.js
@@ -17,7 +17,7 @@ const getTemplate = locale => {
   const yearFormat = yearFormatMap[locale] || 'YYYY';
 
   const template = `
-${locale === 'en' ? '' : "import DatePicker from 'vue2-datepicker';"}
+${locale === 'en' ? '' : "import DatePicker from 'vue2-datepicker-keyup';"}
 import ${formatLocale} from 'date-format-parse/lib/locale/${locale}';
 
 const lang = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue2-datepicker",
+  "name": "vue2-datepicker-keyup",
   "version": "3.8.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "vue2-datepicker",
-  "description": "A Datepicker Component For Vue2",
+  "name": "vue2-datepicker-keyup",
+  "description": "A Datepicker Component For Vue2 with keyup event support",
   "main": "index.js",
   "module": "index.esm.js",
   "alias": {
-    "vue2-datepicker": "./src/index.js"
+    "vue2-datepicker-keyup": "./src/index.js"
   },
   "files": [
     "/locale",
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mengxiong10/vue2-datepicker.git"
+    "url": "git+https://github.com/MrBurrBurr/vue2-datepicker-keyup.git"
   },
   "keywords": [
     "vue",
@@ -113,7 +113,7 @@
       "jest-serializer-vue"
     ],
     "moduleNameMapper": {
-      "vue2-datepicker": "<rootDir>/src"
+      "vue2-datepicker-keyup": "<rootDir>/src"
     },
     "coverageReporters": [
       "text",

--- a/rollup.locale.config.js
+++ b/rollup.locale.config.js
@@ -21,7 +21,7 @@ const plugins = [
 
 const umd = fileList.map(file => {
   const input = path.join(localePath, file);
-  const external = ['vue2-datepicker'];
+  const external = ['vue2-datepicker-keyup'];
   const name = path.basename(file, '.js').replace(/-(\w+)/g, (m, p1) => p1.toUpperCase());
   return {
     input,
@@ -32,7 +32,7 @@ const umd = fileList.map(file => {
       format: 'umd',
       name: `DatePicker.lang.${name}`,
       globals: {
-        'vue2-datepicker': 'DatePicker',
+        'vue2-datepicker-keyup': 'DatePicker',
       },
     },
   };

--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -365,6 +365,12 @@ export default {
       this.$emit('close');
       this.$emit('update:open', false);
     },
+    keyup() {
+      // when use slot input
+      if (this.$refs.input) {
+        this.$refs.input.keyup();
+      }
+    },
     blur() {
       // when use slot input
       if (this.$refs.input) {
@@ -418,6 +424,9 @@ export default {
         this.handleInputChange();
       }
     },
+    handleInputKeyup(evt) {
+      this.$emit('keyup', evt);
+    },
     handleInputBlur(evt) {
       // tab close
       this.$emit('blur', evt);
@@ -456,6 +465,7 @@ export default {
         blur: this.handleInputBlur,
         input: this.handleInputInput,
         change: this.handleInputChange,
+        keyup: this.handleInputKeyup,
       };
       const input = this.renderSlot(
         'input',

--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -211,7 +211,7 @@ export default {
   created() {
     if (typeof this.format === 'object') {
       console.warn(
-        "[vue2-datepicker]: The prop `format` don't support Object any more. You can use the new prop `formatter` to replace it"
+        "[vue2-datepicker-keyup]: The prop `format` don't support Object any more. You can use the new prop `formatter` to replace it"
       );
     }
   },

--- a/src/locale/af.js
+++ b/src/locale/af.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import af from 'date-format-parse/lib/locale/af';
 
 const lang = {

--- a/src/locale/ar-dz.js
+++ b/src/locale/ar-dz.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import arDZ from 'date-format-parse/lib/locale/ar-dz';
 
 const lang = {

--- a/src/locale/ar-sa.js
+++ b/src/locale/ar-sa.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import arSA from 'date-format-parse/lib/locale/ar-sa';
 
 const lang = {

--- a/src/locale/ar.js
+++ b/src/locale/ar.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ar from 'date-format-parse/lib/locale/ar';
 
 const lang = {

--- a/src/locale/az.js
+++ b/src/locale/az.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import az from 'date-format-parse/lib/locale/az';
 
 const lang = {

--- a/src/locale/be.js
+++ b/src/locale/be.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import be from 'date-format-parse/lib/locale/be';
 
 const lang = {

--- a/src/locale/bg.js
+++ b/src/locale/bg.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import bg from 'date-format-parse/lib/locale/bg';
 
 const lang = {

--- a/src/locale/bm.js
+++ b/src/locale/bm.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import bm from 'date-format-parse/lib/locale/bm';
 
 const lang = {

--- a/src/locale/bn.js
+++ b/src/locale/bn.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import bn from 'date-format-parse/lib/locale/bn';
 
 const lang = {

--- a/src/locale/ca.js
+++ b/src/locale/ca.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ca from 'date-format-parse/lib/locale/ca';
 
 const lang = {

--- a/src/locale/cs.js
+++ b/src/locale/cs.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import cs from 'date-format-parse/lib/locale/cs';
 
 const lang = {

--- a/src/locale/cy.js
+++ b/src/locale/cy.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import cy from 'date-format-parse/lib/locale/cy';
 
 const lang = {

--- a/src/locale/da.js
+++ b/src/locale/da.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import da from 'date-format-parse/lib/locale/da';
 
 const lang = {

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import de from 'date-format-parse/lib/locale/de';
 
 const lang = {

--- a/src/locale/el.js
+++ b/src/locale/el.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import el from 'date-format-parse/lib/locale/el';
 
 const lang = {

--- a/src/locale/eo.js
+++ b/src/locale/eo.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import eo from 'date-format-parse/lib/locale/eo';
 
 const lang = {

--- a/src/locale/es.js
+++ b/src/locale/es.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import es from 'date-format-parse/lib/locale/es';
 
 const lang = {

--- a/src/locale/et.js
+++ b/src/locale/et.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import et from 'date-format-parse/lib/locale/et';
 
 const lang = {

--- a/src/locale/fi.js
+++ b/src/locale/fi.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import fi from 'date-format-parse/lib/locale/fi';
 
 const lang = {

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import fr from 'date-format-parse/lib/locale/fr';
 
 const lang = {

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import gl from 'date-format-parse/lib/locale/gl';
 
 const lang = {

--- a/src/locale/gu.js
+++ b/src/locale/gu.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import gu from 'date-format-parse/lib/locale/gu';
 
 const lang = {

--- a/src/locale/he.js
+++ b/src/locale/he.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import he from 'date-format-parse/lib/locale/he';
 
 const lang = {

--- a/src/locale/hi.js
+++ b/src/locale/hi.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import hi from 'date-format-parse/lib/locale/hi';
 
 const lang = {

--- a/src/locale/hr.js
+++ b/src/locale/hr.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import hr from 'date-format-parse/lib/locale/hr';
 
 const lang = {

--- a/src/locale/hu.js
+++ b/src/locale/hu.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import hu from 'date-format-parse/lib/locale/hu';
 
 const lang = {

--- a/src/locale/id.js
+++ b/src/locale/id.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import id from 'date-format-parse/lib/locale/id';
 
 const lang = {

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import is from 'date-format-parse/lib/locale/is';
 
 const lang = {

--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import it from 'date-format-parse/lib/locale/it';
 
 const lang = {

--- a/src/locale/ja.js
+++ b/src/locale/ja.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ja from 'date-format-parse/lib/locale/ja';
 
 const lang = {

--- a/src/locale/ka.js
+++ b/src/locale/ka.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ka from 'date-format-parse/lib/locale/ka';
 
 const lang = {

--- a/src/locale/kk.js
+++ b/src/locale/kk.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import kk from 'date-format-parse/lib/locale/kk';
 
 const lang = {

--- a/src/locale/ko.js
+++ b/src/locale/ko.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ko from 'date-format-parse/lib/locale/ko';
 
 const lang = {

--- a/src/locale/lt.js
+++ b/src/locale/lt.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import lt from 'date-format-parse/lib/locale/lt';
 
 const lang = {

--- a/src/locale/lv.js
+++ b/src/locale/lv.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import lv from 'date-format-parse/lib/locale/lv';
 
 const lang = {

--- a/src/locale/mk.js
+++ b/src/locale/mk.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import mk from 'date-format-parse/lib/locale/mk';
 
 const lang = {

--- a/src/locale/ms.js
+++ b/src/locale/ms.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ms from 'date-format-parse/lib/locale/ms';
 
 const lang = {

--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import nb from 'date-format-parse/lib/locale/nb';
 
 const lang = {

--- a/src/locale/nl-be.js
+++ b/src/locale/nl-be.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import nlBE from 'date-format-parse/lib/locale/nl-be';
 
 const lang = {

--- a/src/locale/nl.js
+++ b/src/locale/nl.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import nl from 'date-format-parse/lib/locale/nl';
 
 const lang = {

--- a/src/locale/pl.js
+++ b/src/locale/pl.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import pl from 'date-format-parse/lib/locale/pl';
 
 const lang = {

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ptBR from 'date-format-parse/lib/locale/pt-br';
 
 const lang = {

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import pt from 'date-format-parse/lib/locale/pt';
 
 const lang = {

--- a/src/locale/ro.js
+++ b/src/locale/ro.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ro from 'date-format-parse/lib/locale/ro';
 
 const lang = {

--- a/src/locale/ru.js
+++ b/src/locale/ru.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ru from 'date-format-parse/lib/locale/ru';
 
 const lang = {

--- a/src/locale/sl.js
+++ b/src/locale/sl.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import sl from 'date-format-parse/lib/locale/sl';
 
 const lang = {

--- a/src/locale/sr.js
+++ b/src/locale/sr.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import sr from 'date-format-parse/lib/locale/sr';
 
 const lang = {

--- a/src/locale/sv.js
+++ b/src/locale/sv.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import sv from 'date-format-parse/lib/locale/sv';
 
 const lang = {

--- a/src/locale/ta.js
+++ b/src/locale/ta.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ta from 'date-format-parse/lib/locale/ta';
 
 const lang = {

--- a/src/locale/te.js
+++ b/src/locale/te.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import te from 'date-format-parse/lib/locale/te';
 
 const lang = {

--- a/src/locale/th.js
+++ b/src/locale/th.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import th from 'date-format-parse/lib/locale/th';
 
 const lang = {

--- a/src/locale/tr.js
+++ b/src/locale/tr.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import tr from 'date-format-parse/lib/locale/tr';
 
 const lang = {

--- a/src/locale/ug-cn.js
+++ b/src/locale/ug-cn.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import ugCN from 'date-format-parse/lib/locale/ug-cn';
 
 const lang = {

--- a/src/locale/uk.js
+++ b/src/locale/uk.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import uk from 'date-format-parse/lib/locale/uk';
 
 const lang = {

--- a/src/locale/vi.js
+++ b/src/locale/vi.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import vi from 'date-format-parse/lib/locale/vi';
 
 const lang = {

--- a/src/locale/zh-cn.js
+++ b/src/locale/zh-cn.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import zhCN from 'date-format-parse/lib/locale/zh-cn';
 
 const lang = {

--- a/src/locale/zh-tw.js
+++ b/src/locale/zh-tw.js
@@ -1,4 +1,4 @@
-import DatePicker from 'vue2-datepicker';
+import DatePicker from 'vue2-datepicker-keyup';
 import zhTW from 'date-format-parse/lib/locale/zh-tw';
 
 const lang = {


### PR DESCRIPTION
I wanted to pass a vue method to the datepicker via the `inputAttr` property. Like this (pseudo code):

```html
<script>
  export default {
    methods: {
      myFunction() {
        console.log('myFunction was called')
      },
    },
  };
</script>

<template>
  <date-picker :inputAttr="{keyup: 'myFunction()'}"></date-picker>
</template>
```

This did not work as expected. It would not recognize my function, I guess since it's a different scope - I didn't bother to investigate.

Anyways, I just added a new event property called `@keyup` and so far it works as expected.

```html
<script>
  export default {
    methods: {
      myFunction() {
        console.log('myFunction was called')
      },
    },
  };
</script>

<template>
  <date-picker @keyup="myFunction()"></date-picker>
</template>
```

I didn't know how to add it to the unittest since I am not familiar with jester and since there are no contribution guidelines I guess it's this is acceptable, so bare with me.