### PR TITLE
Fix: Input time-values via keyboard

### DIFF
--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -239,7 +239,7 @@ export default {
       if (typeof this.getFormatter('parse') === 'function') {
         return this.getFormatter('parse')(value, fmt);
       }
-      const backupDate = new Date();
+      const backupDate = this.inputValue;
       return parse(value, fmt, { locale: this.locale.formatLocale, backupDate });
     },
     formatDate(date, fmt) {


### PR DESCRIPTION
Fills up missing parameters of Date with current inputValue. Otherwise the disabled-date validation get's wrong Date as parameter.