### PR TITLE
fix: add check for 'disabledDate' to be of type 'function'

### DIFF
--- a/src/calendar/calendar-panel.js
+++ b/src/calendar/calendar-panel.js
@@ -112,7 +112,10 @@ export default {
       this.innerCalendar = startOfMonth(calendarDate);
     },
     isDisabled(date) {
-      return this.disabledDate(new Date(date), this.innerValue);
+      if (typeof this.disabledDate === "function") {
+        return this.disabledDate(new Date(date), this.innerValue);
+      }
+      return false;
     },
     emitDate(date, type) {
       if (!this.isDisabled(date)) {


### PR DESCRIPTION
Currently passing for example `null` will pass prop validation, but will crash the `CalendarPanel` component with the error: "Error in render: "TypeError: this.disabledDate is not a function"

Adding this simple check will ensure that passing `null`  or `undefined` will not crash the library and act as if the prop was not passed at all