### PR TITLE
feat: add default icon for 'time' type

### DIFF
--- a/src/date-picker.js
+++ b/src/date-picker.js
@@ -4,6 +4,7 @@ import { pick, isObject, mergeDeep } from './util/base';
 import { getLocale } from './locale';
 import Popup from './popup';
 import IconCalendar from './icon/icon-calendar';
+import IconTime from './icon/icon-time';
 import IconClose from './icon/icon-close';
 import CalendarPanel from './calendar/calendar-panel';
 import CalendarRange from './calendar/calendar-range';
@@ -465,6 +466,7 @@ export default {
           events,
         }
       );
+      const calendarIcon = this.type === 'time' ? <IconTime /> : <IconCalendar />;
       return (
         <div class={`${prefixClass}-input-wrapper`} onMousedown={this.openPopup}>
           {input}
@@ -474,7 +476,7 @@ export default {
             </i>
           ) : null}
           <i class={`${prefixClass}-icon-calendar`}>
-            {this.renderSlot('icon-calendar', <IconCalendar />)}
+            {this.renderSlot('icon-calendar', calendarIcon)}
           </i>
         </div>
       );

--- a/src/icon/icon-time.vue
+++ b/src/icon/icon-time.vue
@@ -1,0 +1,9 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24px" height="24px">
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+    />
+    <path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z" />
+  </svg>
+</template>


### PR DESCRIPTION
This is a simple improvement, we use time icon when using a **time** type.

Here the example.
![Time Icon Example](https://user-images.githubusercontent.com/11625690/111579732-7da89380-87f1-11eb-80bc-e370f6ac59af.png)

Time icon from https://material.io/resources/icons/?search=time&icon=schedule&style=baseline
