### PR TITLE
feat: add watch for change panel type

### DIFF
--- a/src/calendar/calendar-panel.js
+++ b/src/calendar/calendar-panel.js
@@ -101,6 +101,11 @@ export default {
     defaultValue: {
       handler: 'initCalendar',
     },
+    type: {
+      handler: function(val) {
+        this.handelPanelChange(val);
+      },
+    },
   },
   methods: {
     initCalendar() {


### PR DESCRIPTION
When we need to choose from a few types of periods (i.e. day, week, month, year), it's necessary to change panel type with reactivity. 
This feature adds watch for types of **Calendar Panel** . So, when we change the panel type of **Calendar Panel**, new panel type is shown immediately.
![1](https://user-images.githubusercontent.com/8161891/113118974-9e70e000-9218-11eb-9158-1ec0e2f7c1d7.PNG)
![2](https://user-images.githubusercontent.com/8161891/113118982-a0d33a00-9218-11eb-8068-7a6ed1f99176.PNG)

