### PR TITLE
fix: move vertical-align to td, th to avoid UA style dependency (#608)

### DIFF
--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -248,13 +248,15 @@
   height: 100%;
   box-sizing: border-box;
   text-align: center;
-  vertical-align: middle;
+
   th {
     padding: 0;
     font-weight: 500;
+    vertical-align: middle;
   }
   td {
     padding: 0;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
Fixes #608 by moving `vertical-align` propery to `td` and `th` tags as style defined on `table` has no effect (at least in Google Chrome) because of inheritnce of `td` and `th` on `tbody` and `thead` which does not inherit `vertical-align` from `table` by default.