### PR TITLE
Add data-selector for time lists

### DIFF
--- a/src/time/list-columns.vue
+++ b/src/time/list-columns.vue
@@ -11,6 +11,7 @@
           v-for="(item, j) in col.list"
           :key="item.value"
           :data-index="j"
+          :data-content="item.text"
           :class="[`${prefixClass}-time-item`, getClasses(item.value, col.type)]"
         >
           {{ item.text }}


### PR DESCRIPTION
This addition should make it easier during testing with e2e tools like cypress to select the right time.